### PR TITLE
Create unique add-on id

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
   "permissions": ["storage", "*://content.guardianapis.com/*"],
   "browser_specific_settings": {
     "gecko": {
-      "id": "sindicator@the-guardian.com",
+      "id": "sindicator@guardian.co.uk",
       "strict_min_version": "58.0"
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
   "permissions": ["storage", "*://content.guardianapis.com/*"],
   "browser_specific_settings": {
     "gecko": {
-      "id": "sindicator@theguardian.com",
+      "id": "sindicator@the-guardian.com",
       "strict_min_version": "58.0"
     }
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of PR #1 I had created numerous versions of the add-on on the Developer Hub whilst testing the installation process.  I manually deleted the add-on so that I could reset the version number to 1.0.0

However, when merging PR #1 the build and sign process failed, because the add-on id was not unique.

This PR has simply changed the add-on id to ensure that it does not clash with the previously deleted one.

## How to test

Merge the PR! 

## How can we measure success?

The build and sign should work correctly, making v1.0.0 of the web extension available

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
