### PR TITLE
Add pre-commit hook for linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint:ext

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run lint:ext

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "sIndicator",
-  "version": "1.0.0",
+  "version": "1.0.1",
 
   "description": "Indicates whether an article on theguardian.com is available for syndication.",
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
     "devDependencies": {
         "@types/node": "^20.14.10",
+        "husky": "^9.1.6",
         "typescript": "^5.5.3",
+        "web-ext": "^8.3.0",
         "web-ext-types": "^3.2.1"
     },
     "scripts": {
         "preinstall": "node -e \"if (process.env.npm_execpath.indexOf('yarn') === -1) { console.error('\\x1b[31mERROR: Please use Yarn to install dependencies instead of npm.\\x1b[0m'); process.exit(1); }\"",
-        "build": "tsc && bash build.sh"
-    },
-    "dependencies": {}
+        "build": "tsc && bash build.sh",
+        "prepare": "husky",
+        "lint:ext": "web-ext lint"
+    }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In order to create a signed extension for use in Mozilla Firefox, the extension source must first be validated using `web-ext lint`.  This step has been added as a pre-commit.

## How to test

Make a change which is not allowed by `web-ext lint` (e.g. using `/*` for comments in `tsconfig.json`) and attempt to commit your changes.  The commit will be prevented.

## How can we measure success?

No nasty surprises when merging PRs

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
