### PR TITLE
Sign on release instead of merge

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -30,7 +30,7 @@ jobs:
         fi
 
     - name: Simulate release version
-      run: echo "RELEASE_VERSION=1.0.0-test" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=1.0.0.0" >> $GITHUB_ENV
 
     - name: Update manifest.json with version
       run: |

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -1,8 +1,9 @@
 name: Build and Sign Web Extension
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - 
 
 jobs:
   build-and-sign:
@@ -28,9 +29,8 @@ jobs:
           sudo apt-get update && sudo apt-get install -y jq
         fi
 
-    - name: Extract version from release tag
-      id: extract_version
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+    - name: Simulate release version
+      run: echo "RELEASE_VERSION=1.0.0-test" >> $GITHUB_ENV
 
     - name: Update manifest.json with version
       run: |

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -1,9 +1,8 @@
 name: Build and Sign Web Extension
 
 on:
-  push:
-    branches:
-      - 
+  release:
+    types: [published]
 
 jobs:
   build-and-sign:
@@ -29,8 +28,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y jq
         fi
 
-    - name: Simulate release version
-      run: echo "RELEASE_VERSION=1.0.0.0" >> $GITHUB_ENV
+    - name: Extract version from release tag
+      id: extract_version
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
     - name: Update manifest.json with version
       run: |

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -1,9 +1,8 @@
 name: Build and Sign Web Extension
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   build-and-sign:
@@ -22,6 +21,21 @@ jobs:
 
     - name: Install dependencies
       run: yarn install
+
+    - name: Install jq if not already installed
+      run: |
+        if ! command -v jq &> /dev/null; then
+          sudo apt-get update && sudo apt-get install -y jq
+        fi
+
+    - name: Extract version from release tag
+      id: extract_version
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+    - name: Update manifest.json with version
+      run: |
+        jq --arg version "$RELEASE_VERSION" '.version = $version' manifest.json > manifest.tmp.json
+        mv manifest.tmp.json manifest.json
 
     - name: Build the project
       run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 jobs:
-  build-and-sign:
+  build-extension:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Web Extension
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build-and-sign:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20.x
+        cache: "yarn"
+        cache-dependency-path: yarn.lock
+
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Build the project
+      run: yarn build
+
+    - name: Install web-ext
+      run: yarn global add web-ext
+
+    - name: Build the extension
+      run: web-ext build

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,4 +1,4 @@
-name: Build and Sign Web Extension
+name: Sign Web Extension
 
 on:
   release:
@@ -11,17 +11,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 20.x
-        cache: "yarn"
-        cache-dependency-path: yarn.lock
-
-    - name: Install dependencies
-      run: yarn install
-
+      
     - name: Install jq if not already installed
       run: |
         if ! command -v jq &> /dev/null; then
@@ -36,9 +26,6 @@ jobs:
       run: |
         jq --arg version "$RELEASE_VERSION" '.version = $version' manifest.json > manifest.tmp.json
         mv manifest.tmp.json manifest.json
-
-    - name: Build the project
-      run: yarn build
 
     - name: Install web-ext
       run: yarn global add web-ext

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  build-and-sign:
+  sign-extension:
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Either use `web-ext run`
 Or install manually into your browser using debug mode
 
 ## Building and signing the web extension
-You will need to update the version in `manifest.json` as part of your PR
+The version in `manifest.json` is a placeholder: it does not need to be updated manually as it will be replaced by the GitHub Actions workflow
 
 Repository secrets have been added for WEB_EXT_API_KEY and WEB_EXT_API_SECRET
 
 If these need to be updated, [create](https://accounts.firefox.com/) a mozilla account and request an API key
 
-A GitHub action is activated on merging a PR and uses [web-ext](https://github.com/mozilla/web-ext) to build and sign the web extension
+A GitHub action is activated on Release and uses [web-ext](https://github.com/mozilla/web-ext) to build and sign the web extension for use with Mozilla Firefox
 
 A zip file containing the signed xpi can be accessed from the Artifacts for the action
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "sIndicator",
-  "version": "1.0.0",
+  "version": "0.0.0", 
 
   "description": "Indicates whether an article on theguardian.com is available for syndication.",
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changes the workflow so that the web extension is signed as part of the Release process, instead of when the PR is merged to main.  The original `build-and-sign.yml` has been split into two separate workflows:
- build.yml - triggered when pushing to a branch
- sign.yml - triggered on release

When signing, the version number will be extracted from the release tag.  The version in `manifest.json` therefore no longer needs to be updated, as it is now only a placeholder.

This will avoid the need to increase the version number when no changes have been made to the actual web extension.

## How to test

I made temporary changes to `build-and-sign.yml` (before splitting into 2 separate workflows) so that the version number was saved to a variable and the extension was signed when I pushing to the branch.  

As for testing that it works as expected on Release, we'll have to merge the PR first!

## How can we measure success?

Greater control over when a new version is created, and therefore a reduction in changes to the version number

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
